### PR TITLE
Add playbook example for assigning Proxmox role to group

### DIFF
--- a/example/assign_role_to_group.yml
+++ b/example/assign_role_to_group.yml
@@ -1,0 +1,35 @@
+---
+- name: Associate a role with a group on a resource
+  hosts: cluster_nodes
+  gather_facts: false
+  vars:
+    api_host: "{{ ansible_play_hosts | first }}"
+    user: test
+    domain: pve
+    validate_certs: false
+    api_password: test1234
+    group_name: example_group
+    path: "/"
+    role_name: "NoAccess"
+  tasks:
+  - name: run from controller
+    delegate_to: example-controller
+    block:
+    - name: Ensure group exists
+      community.proxmox.proxmox_group:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password }}"
+        validate_certs: "{{ validate_certs }}"
+        name: "{{ group_name }}"
+    - name: Associate role with group
+      community.proxmox.proxmox_access_acl:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password }}"
+        validate_certs: "{{ validate_certs }}"
+        state: present
+        path: "{{ path }}"
+        roleid: "{{ role_name }}"
+        type: group
+        ugid: "{{ group_name }}"

--- a/example/revoke_role_from_group.yml
+++ b/example/revoke_role_from_group.yml
@@ -1,0 +1,36 @@
+---
+- name: Remove a role from a group on a resource
+  hosts: cluster_nodes
+  gather_facts: false
+  vars:
+    api_host: "{{ ansible_play_hosts | first }}"
+    user: test
+    domain: pve
+    validate_certs: false
+    api_password: test1234
+    group_name: example_group
+    path: "/"
+    role_name: "NoAccess"
+  tasks:
+  - name: run from controller
+    delegate_to: example-controller
+    block:
+    - name: Disassociate role from group
+      community.proxmox.proxmox_access_acl:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password }}"
+        validate_certs: "{{ validate_certs }}"
+        state: absent
+        path: "{{ path }}"
+        roleid: "{{ role_name }}"
+        type: group
+        ugid: "{{ group_name }}"
+    - name: Remove group
+      community.proxmox.proxmox_group:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password }}"
+        validate_certs: "{{ validate_certs }}"
+        name: "{{ group_name }}"
+        state: absent


### PR DESCRIPTION
## Summary
- add `assign_role_to_group.yml` example playbook

## Testing
- `nox -e docs-check` *(fails: ansible-galaxy collection list)*
- `nox -e ansible-test-sanity-2.17-3.12` *(fails: ansible-galaxy collection list)*
- `nox -e ansible-test-units-2.17-3.12` *(fails: ansible-galaxy collection list)*

------
https://chatgpt.com/codex/tasks/task_b_6886068a8604832492db35609aaa27db